### PR TITLE
fix(agent): resolve infinite recursion in slide generation graph

### DIFF
--- a/apps/backend/src/slideia/domain/agent/graph.py
+++ b/apps/backend/src/slideia/domain/agent/graph.py
@@ -34,11 +34,8 @@ def decide_validation(state: AgentState) -> str:
         # Loop back to generate/refine
         intent = state.get("intent")
         if intent == "CREATE_DECK":
-            # Increment retry count
-            state["retry_count"] = retry_count + 1
             return "draft_slides"
         elif intent == "EDIT_DECK":
-            state["retry_count"] = retry_count + 1
             return "refine_deck"
 
     return END

--- a/apps/backend/src/slideia/domain/agent/nodes.py
+++ b/apps/backend/src/slideia/domain/agent/nodes.py
@@ -323,19 +323,28 @@ async def validate_node(state: AgentState, config: RunnableConfig) -> dict:
     logger.info("Node: validate_node")
 
     deck = state.get("deck")
+    error_msg = None
+
     if not deck or "slides" not in deck:
-        return {"error": "No slides found in the generated deck."}
+        error_msg = "No slides found in the generated deck."
+    else:
+        slides = deck["slides"]
+        if not slides:
+            error_msg = "The slide list is empty."
+        else:
+            # Verify formatting constraints on slides
+            for idx, s in enumerate(slides):
+                if not s.get("title"):
+                    error_msg = f"Slide {idx + 1} is missing a title."
+                    break
+                if not isinstance(s.get("bullets"), list):
+                    error_msg = f"Slide {idx + 1} ('{s.get('title')}') bullets must be a list of strings."
+                    break
 
-    slides = deck["slides"]
-    if not slides:
-        return {"error": "The slide list is empty."}
-
-    # Verify formatting constraints on slides
-    for idx, s in enumerate(slides):
-        if not s.get("title"):
-            return {"error": f"Slide {idx + 1} is missing a title."}
-        if not isinstance(s.get("bullets"), list):
-            return {"error": f"Slide {idx + 1} ('{s.get('title')}') bullets must be a list of strings."}
+    if error_msg:
+        retry_count = state.get("retry_count", 0) + 1
+        logger.warning(f"Validation failed (retry {retry_count}/3): {error_msg}")
+        return {"error": error_msg, "retry_count": retry_count}
 
     # If it passed validation, clear error
     return {"error": None}

--- a/apps/backend/tests/domain/test_agent.py
+++ b/apps/backend/tests/domain/test_agent.py
@@ -1,5 +1,7 @@
 from langgraph.graph import END
+import pytest
 from slideia.domain.agent.graph import route_intent, decide_validation, compile_workflow
+from slideia.domain.agent.nodes import validate_node
 from slideia.domain.agent.state import AgentState
 
 
@@ -79,3 +81,61 @@ def test_graph_compilation():
     assert "refine_deck" in node_names
     assert "validate" in node_names
     assert "general_chat" in node_names
+
+
+@pytest.mark.asyncio
+async def test_validate_node():
+    # 1. State with no deck
+    state_no_deck: AgentState = {
+        "messages": [],
+        "topic": "AI",
+        "audience": "Developers",
+        "tone": "professional",
+        "slide_count": 3,
+        "theme_preset": "purple_mint",
+        "deck": None,
+        "prompt": "Create a deck",
+        "file_context": "",
+        "intent": "CREATE_DECK",
+        "instruction": None,
+        "error": None,
+        "retry_count": 0,
+    }
+    res = await validate_node(state_no_deck, None)
+    assert res["error"] == "No slides found in the generated deck."
+    assert res["retry_count"] == 1
+
+    # 2. State with valid deck
+    state_valid_deck: AgentState = {
+        **state_no_deck,
+        "deck": {
+            "slides": [
+                {
+                    "title": "Slide 1",
+                    "layout": "bullets",
+                    "bullets": ["Bullet 1", "Bullet 2"],
+                }
+            ]
+        },
+        "retry_count": 1,
+    }
+    res = await validate_node(state_valid_deck, None)
+    assert res["error"] is None
+    assert "retry_count" not in res
+
+    # 3. State with invalid slide (missing title)
+    state_invalid_deck: AgentState = {
+        **state_no_deck,
+        "deck": {
+            "slides": [
+                {
+                    "layout": "bullets",
+                    "bullets": ["Bullet 1"],
+                }
+            ]
+        },
+        "retry_count": 2,
+    }
+    res = await validate_node(state_invalid_deck, None)
+    assert "missing a title" in res["error"]
+    assert res["retry_count"] == 3


### PR DESCRIPTION
- Increment retry_count in validate_node (persisted state)
- Remove state mutation from decide_validation routing function
- Add test_validate_node unit test to test_agent.py

Co-authored-by: Antigravity - Gemini 3.5 Flash (Medium)